### PR TITLE
Allow form content to be overridden using partials

### DIFF
--- a/app/helpers/wizardry_helper.rb
+++ b/app/helpers/wizardry_helper.rb
@@ -14,18 +14,9 @@ private
 
   def render_form
     capture do
-      if lookup_context.template_exists?(page_partial_file_path)
-        Rails.logger.warn("🧙 Page partial #{page_partial_file_path} found; rendering entire page")
-
-        concat(render(partial: page_partial_render_path))
-      else
+      try_partial('page') do
         wizard_form do |f|
-          if lookup_context.template_exists?(form_partial_file_path)
-            Rails.logger.warn("🧙 Form partial #{form_partial_file_path} found; rendering just the form")
-
-            concat(render(partial: form_partial_render_path, locals: { f: f }))
-          else
-            Rails.logger.warn("🧙 No overriding form partial found; automatically building form")
+          try_partial('form', locals: { f: f }) do
             concat(f.govuk_error_summary)
 
             @wizard.current_page.questions.map do |q|
@@ -41,47 +32,47 @@ private
 
   def render_check_your_answers
     capture do
-      if lookup_context.template_exists?(page_partial_file_path)
-        Rails.logger.warn("🧙 Page partial #{page_partial_file_path} found; rendering entire page")
-
-        concat(render(partial: page_partial_render_path))
-      else
-        safe_join([
-          render(GovukComponent::SummaryListComponent.new) do |summary_list|
-            @wizard.route.each do |page|
-              page.questions.each do |question|
-                summary_list.row do |sl|
-                  sl.key(text: check_your_answers_key(@wizard.object.class.name, question.name))
-                  sl.value(text: @wizard.object.send(question.name))
-                  sl.action(href: send(@wizard.framework.edit_path_helper, page.name))
+      try_partial('page') do
+        safe_join(
+          [
+            render(GovukComponent::SummaryListComponent.new) do |summary_list|
+              @wizard.route.each do |page|
+                page.questions.each do |question|
+                  summary_list.row do |sl|
+                    sl.key(text: check_your_answers_key(@wizard.object.class.name, question.name))
+                    sl.value(text: @wizard.object.send(question.name))
+                    sl.action(href: send(@wizard.framework.edit_path_helper, page.name))
+                  end
                 end
               end
             end
-          end,
-        ])
+          ]
+        )
       end
     end
   end
 
   def render_completion
     capture do
-      if lookup_context.template_exists?(page_partial_file_path)
-        Rails.logger.warn("🧙 Page partial #{page_partial_file_path} found; rendering entire page")
+      try_partial('page') do
+        safe_join(
+          [
+            tag.h1('Completed'),
 
-        concat(render(partial: page_partial_render_path))
-      else
-        safe_join([
-          tag.h1('Completed'),
-
-          tag.p do
-            ["Add a partial called", tag.code(%(_completion.html.erb)), "to override this message"].join(" ").html_safe
-          end
-        ])
+            tag.p do
+              [
+                'Add a partial called',
+                tag.code(%(_completion.html.erb)),
+                'to override this message'
+              ].join(' ').html_safe
+            end
+          ]
+        )
       end
     end
   end
 
-  def wizard_form(turbo_frame_id: "wizardry-form", &block)
+  def wizard_form(turbo_frame_id: 'wizardry-form', &block)
     turbo_frame_tag(turbo_frame_id) do
       safe_join(
         [
@@ -100,30 +91,26 @@ private
     end
   end
 
+  def try_partial(section, locals: {}, &block)
+    if lookup_context.template_exists?(partial_file_path(section))
+      Rails.logger.debug("🧙 Page partial #{partial_file_path(section)} found; rendering entire page")
+
+      concat(render(partial: partial_render_path(section), locals: locals))
+    else
+      Rails.logger.debug('🧙 No overriding form partial found; automatically building form')
+
+      block.call
+    end
+  end
+
   def check_your_answers_key(class_name, question_name)
     I18n.t!("helpers.legend.#{class_name.underscore}.#{question_name}")
   rescue I18n::MissingTranslationData
     I18n.t("helpers.label.#{class_name.underscore}.#{question_name}")
   end
 
-  def form_partial_file_path
-    partial_file_path("form")
-  end
-
-  def page_partial_file_path
-    partial_file_path("page")
-  end
-
   def partial_file_path(suffix)
     "#{@wizard.framework.name}/_#{@wizard.current_page.name}_#{suffix}"
-  end
-
-  def form_partial_render_path
-    partial_render_path("form")
-  end
-
-  def page_partial_render_path
-    partial_render_path("page")
   end
 
   def partial_render_path(suffix)

--- a/spec/dummy/app/controllers/ratings_controller.rb
+++ b/spec/dummy/app/controllers/ratings_controller.rb
@@ -15,7 +15,8 @@ class RatingsController < ApplicationController
           Wizardry::Questions::EmailAddress.new(:name)
         ],
         next_pages: [
-          Wizardry::Routing::NextPage.new(:name_check, proc { |o| o.full_name =~ /(John|Jane) Doe/ })
+          Wizardry::Routing::NextPage.new(:name_check, proc { |o| o.full_name =~ /(John|Jane) Doe/ }),
+          Wizardry::Routing::NextPage.new(:are_you_sure, proc { |o| o.full_name == "Joe Bloggs" })
         ],
         pages: [
           Wizardry::Pages::QuestionPage.new(
@@ -23,6 +24,13 @@ class RatingsController < ApplicationController
             title: 'Is that your real name?',
             questions: [
               Wizardry::Questions::Radios.new(:name_check, { true => 'Yes', false => 'No' })
+            ],
+          ),
+          Wizardry::Pages::QuestionPage.new(
+            :are_you_sure,
+            title: 'Are you sure?',
+            questions: [
+              Wizardry::Questions::Radios.new(:are_you_sure, { true => 'Yes', false => 'No' })
             ],
           )
         ],

--- a/spec/dummy/app/controllers/ratings_controller.rb
+++ b/spec/dummy/app/controllers/ratings_controller.rb
@@ -13,7 +13,19 @@ class RatingsController < ApplicationController
         questions: [
           Wizardry::Questions::ShortAnswer.new(:full_name),
           Wizardry::Questions::EmailAddress.new(:name)
-        ]
+        ],
+        next_pages: [
+          Wizardry::Routing::NextPage.new(:name_check, proc { |o| o.full_name =~ /(John|Jane) Doe/ })
+        ],
+        pages: [
+          Wizardry::Pages::QuestionPage.new(
+            :name_check,
+            title: 'Is that your real name?',
+            questions: [
+              Wizardry::Questions::Radios.new(:name_check, { true => 'Yes', false => 'No' })
+            ],
+          )
+        ],
       ),
       Wizardry::Pages::QuestionPage.new(
         :address,

--- a/spec/dummy/app/models/rating.rb
+++ b/spec/dummy/app/models/rating.rb
@@ -10,6 +10,10 @@ class Rating < ApplicationRecord
     presence: { message: "Tell us how we should address you" },
     on: :identification
 
+  validates :name_check,
+    inclusion: { in: [true], message: "Please answer the questions truthfully" },
+    on: :name_check
+
   validates :address_1, presence: true, on: :address
   validates :postcode, presence: true, on: :address
 

--- a/spec/dummy/app/models/rating.rb
+++ b/spec/dummy/app/models/rating.rb
@@ -14,6 +14,10 @@ class Rating < ApplicationRecord
     inclusion: { in: [true], message: "Please answer the questions truthfully" },
     on: :name_check
 
+  validates :are_you_sure,
+    inclusion: { in: [true], message: "Enter an answer" },
+    on: :are_you_sure
+
   validates :address_1, presence: true, on: :address
   validates :postcode, presence: true, on: :address
 

--- a/spec/dummy/app/views/ratings/_are_you_sure_page.html.erb
+++ b/spec/dummy/app/views/ratings/_are_you_sure_page.html.erb
@@ -1,0 +1,20 @@
+<h1>Really sure?</h1>
+
+<p>Text from the partial</p>
+
+<%= turbo_frame_tag("some-id") do %>
+  <%= form_for(
+    @wizard.object,
+    url: send(
+      @wizard.framework.update_path_helper,
+      page: @wizard.current_page.name),
+      method: :patch,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+  ) do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <%= f.govuk_text_field :are_you_sure %>
+
+    <%= f.govuk_submit %>
+  <% end %>
+<% end %>

--- a/spec/dummy/app/views/ratings/_name_check_form.html.erb
+++ b/spec/dummy/app/views/ratings/_name_check_form.html.erb
@@ -1,0 +1,8 @@
+<%= f.govuk_error_summary %>
+
+<%= f.govuk_radio_buttons_fieldset(:name_check) do %>
+  <%= f.govuk_radio_button(:name_check, true, label: { text: "Yes, it's really my name" }) %>
+  <%= f.govuk_radio_button(:name_check, false, label: { text: "No, my name's something else entirely" }) %>
+<% end %>
+
+<%= f.govuk_submit %>

--- a/spec/dummy/app/views/ratings/_name_check_form.html.erb
+++ b/spec/dummy/app/views/ratings/_name_check_form.html.erb
@@ -1,5 +1,7 @@
 <%= f.govuk_error_summary %>
 
+<p>Text from the partial</p>
+
 <%= f.govuk_radio_buttons_fieldset(:name_check) do %>
   <%= f.govuk_radio_button(:name_check, true, label: { text: "Yes, it's really my name" }) %>
   <%= f.govuk_radio_button(:name_check, false, label: { text: "No, my name's something else entirely" }) %>

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
       rating:
         full_name: What is your full name?
         name: What should we call you?
+        are_you_sure: Are you sure?
 
         address_1: Address line one
         address_2: Address line two

--- a/spec/dummy/db/migrate/20200921151347_create_ratings.rb
+++ b/spec/dummy/db/migrate/20200921151347_create_ratings.rb
@@ -7,6 +7,8 @@ class CreateRatings < ActiveRecord::Migration[6.0]
       t.string "full_name"
       t.string "name"
 
+      t.boolean "name_check"
+
       t.string "address_1"
       t.string "address_2"
       t.string "town"

--- a/spec/dummy/db/migrate/20200921151347_create_ratings.rb
+++ b/spec/dummy/db/migrate/20200921151347_create_ratings.rb
@@ -8,6 +8,7 @@ class CreateRatings < ActiveRecord::Migration[6.0]
       t.string "name"
 
       t.boolean "name_check"
+      t.boolean "are_you_sure"
 
       t.string "address_1"
       t.string "address_2"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2020_09_21_151347) do
     t.string "full_name"
     t.string "name"
     t.boolean "name_check"
+    t.boolean "are_you_sure"
     t.string "address_1"
     t.string "address_2"
     t.string "town"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema.define(version: 2020_09_21_151347) do
     t.string "last_completed_step"
     t.string "full_name"
     t.string "name"
+    t.boolean "name_check"
     t.string "address_1"
     t.string "address_2"
     t.string "town"

--- a/spec/features/custom_form_partials_spec.rb
+++ b/spec/features/custom_form_partials_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe('Completing the wizard: with optional pages', type: :feature) do
+  include_context "common wizard steps"
+
+  scenario "Form contents can be overridden with partials" do
+    given_a_partial_exists_for_the_name_check_form
+    and_i_begin_the_wizard
+
+    # page 1: identification
+    when_i_fill_in_the_identification_page
+    and_i_submit_the_form
+ 
+    # Note the wizard is set to go to the :name_check step when the full name
+    # of 'John Doe' or 'Jane Doe' is submitted
+    #
+    # page 2: name check
+    then_i_should_be_on_the_name_check_page
+    and_i_see_the_customised_form_partial_content
+
+    # Fill in incorrectly to ensure errors rendered properly
+    when_i_select "No, my name's something else entirely"
+    and_i_submit_the_form
+    then_i_should_see_an_error_message
+
+    # Now fill in correctly and ensure we proceed
+    when_i_select "Yes, it's really my name"
+    and_i_submit_the_form
+    then_i_should_be_on_the_address_page
+  end
+
+private
+
+  def responses
+    @responses ||= OpenStruct.new(full_name: 'John Doe', name: 'John')
+  end
+
+  def given_a_partial_exists_for_the_name_check_form
+    expect(File).to exist(Rails.root.join("app", "views", "ratings", "_name_check_form.html.erb"))
+  end
+
+  def then_i_should_be_on_the_name_check_page
+    expect(page.current_path).to eql('/rating/name_check')
+  end
+
+  def and_i_see_the_customised_form_partial_content
+    expect(page).to have_css('label', text: "Yes, it's really my name")
+    expect(page).to have_css('label', text: "No, my name's something else entirely")
+    expect(page).to have_css('button', text: "Continue")
+  end
+
+  def then_i_should_see_an_error_message
+    expect(page).to have_css('.govuk-error-summary', text: 'There is a problem')
+    expect(page).to have_css('.govuk-form-group--error', text: /Please answer the questions truthfully/)
+  end
+end

--- a/spec/features/custom_page_partials_spec.rb
+++ b/spec/features/custom_page_partials_spec.rb
@@ -1,6 +1,7 @@
+
 require 'rails_helper'
 
-RSpec.describe('Completing the wizard: custom form partials', type: :feature) do
+RSpec.describe('Completing the wizard: custom page partials', type: :feature) do
   include_context "common wizard steps"
 
   scenario "Form contents can be overridden with partials" do
@@ -11,20 +12,20 @@ RSpec.describe('Completing the wizard: custom form partials', type: :feature) do
     when_i_fill_in_the_identification_page
     and_i_submit_the_form
  
-    # Note the wizard is set to go to the :name_check step when the full name
-    # of 'John Doe' or 'Jane Doe' is submitted
+    # Note the wizard is set to go to the :are_you_sure step when the full name
+    # of 'Joe Bloggs' is submitted
     #
     # page 2: name check
-    then_i_should_be_on_the_name_check_page
-    and_i_see_the_customised_form_partial_content
+    then_i_should_be_on_the_are_you_sure_page
+    and_i_see_the_customised_page_partial_content
 
     # Fill in incorrectly to ensure errors rendered properly
-    when_i_select "No, my name's something else entirely"
+    when_i_dont_enter_anything
     and_i_submit_the_form
     then_i_should_see_an_error_message
 
     # Now fill in correctly and ensure we proceed
-    when_i_select "Yes, it's really my name"
+    when_i_confirm_that_im_sure
     and_i_submit_the_form
     then_i_should_be_on_the_address_page
   end
@@ -32,26 +33,31 @@ RSpec.describe('Completing the wizard: custom form partials', type: :feature) do
 private
 
   def responses
-    @responses ||= OpenStruct.new(full_name: 'John Doe', name: 'John')
+    @responses ||= OpenStruct.new(full_name: 'Joe Bloggs', name: 'Joe')
   end
 
   def given_a_partial_exists_for_the_name_check_form
     expect(File).to exist(Rails.root.join("app", "views", "ratings", "_name_check_form.html.erb"))
   end
 
-  def then_i_should_be_on_the_name_check_page
-    expect(page.current_path).to eql('/rating/name_check')
+  def then_i_should_be_on_the_are_you_sure_page
+    expect(page.current_path).to eql('/rating/are_you_sure')
   end
 
-  def and_i_see_the_customised_form_partial_content
+  def when_i_dont_enter_anything; end
+
+  def when_i_confirm_that_im_sure
+    fill_in 'Are you sure?', with: 'true'
+  end
+
+  def and_i_see_the_customised_page_partial_content
+    expect(page).to have_css('h1', text: 'Really sure?')
     expect(page).to have_css('p', text: 'Text from the partial')
-    expect(page).to have_css('label', text: "Yes, it's really my name")
-    expect(page).to have_css('label', text: "No, my name's something else entirely")
     expect(page).to have_css('button', text: "Continue")
   end
 
   def then_i_should_see_an_error_message
     expect(page).to have_css('.govuk-error-summary', text: 'There is a problem')
-    expect(page).to have_css('.govuk-form-group--error', text: /Please answer the questions truthfully/)
+    expect(page).to have_css('.govuk-form-group--error', text: /Enter an answer/)
   end
 end

--- a/spec/support/shared/common_steps.rb
+++ b/spec/support/shared/common_steps.rb
@@ -6,6 +6,7 @@ RSpec.shared_context "common wizard steps" do
   def given_i_begin_the_wizard
     visit 'rating/identification'
   end
+  alias_method :and_i_begin_the_wizard, :given_i_begin_the_wizard
 
   def when_i_fill_in_the_identification_page
     fill_in 'What is your full name?', with: responses.full_name
@@ -30,6 +31,11 @@ RSpec.shared_context "common wizard steps" do
     # ignore date for the moment, it's non-trivial to fill in
     choose responses.rating
   end
+
+  def when_i_select(option)
+    choose(option)
+  end
+  alias_method :when_i_choose, :when_i_select
 
   def and_i_submit_the_form
     click_on 'Continue'


### PR DESCRIPTION
Often there's need for custom content on forms. While the form builder's built in localisation support allows labels, legends, captions and hints to be automatically injected, sometimes extra explanatory or background text is needed. Alternatively, custom form components (e.g., a rich text editor or star rating) might be needed.

Instead of adding extra capabilities to the wizard to support passing these values in, telling the wizard what params to expect and allowing writers to build the form contents themselves seems like a nicer approach.

This change alters the behavious so that when a page is rendered the wizard will look for a partial. On a wizard called `pizza_orders` on the `toppings` page, the partial it'll look for should be called `pizza_orders/_toppings_form`.

I'm not sure whether the `_form` suffix is necessary - it might confuse things when we want to customise the 'Check your answers' or 'Completion' pages. Perhaps they should be `pizza_orders/_check_your_answers_page`? 🤔 

## Changes

- Add a name_check flag to the rating object
- Add a question page with overriding form partial
- Make the question page look for partials first
- Add feature spec covering custom form rendering
