### PR TITLE
Intelligent routing when reviewing answers

### DIFF
--- a/lib/wizardry/instance.rb
+++ b/lib/wizardry/instance.rb
@@ -15,6 +15,16 @@ module Wizardry
       next_branch_page(page) || next_trunk_page(page)
     end
 
+    def next_incomplete_page(page = current_page)
+      np = next_page(page)
+
+      loop do
+        break np unless valid_on?(np.name)
+
+        np = next_page(np)
+      end
+    end
+
     # find all the pages we've visited on our way to
     # the current page
     def route(from = framework.pages.first)
@@ -33,8 +43,12 @@ module Wizardry
       end
     end
 
-    def valid_so_far?
-      route.all? { |complete_page| object.valid?(complete_page.name) }
+    def valid_so_far?(from = framework.pages.first)
+      route(from).all? { |complete_page| valid_on?(complete_page.name) }
+    end
+
+    def valid_on?(page_name)
+      object.valid?(page_name)
     end
 
     # check this wizard hasn't already been completed using the

--- a/spec/lib/wizardry/instance_spec.rb
+++ b/spec/lib/wizardry/instance_spec.rb
@@ -32,6 +32,15 @@ describe Wizardry::Instance do
     end
   end
 
+  describe '#next_incomplete_page' do
+    let(:current_page_name) { :page_two }
+    let(:object_attributes) { { field_one: 'abc', field_two: 'def' } }
+
+    specify "correctly identifies the next incomplete page" do
+      expect(subject.next_incomplete_page.name).to eql(:page_three)
+    end
+  end
+
   describe '#route' do
     it { is_expected.to respond_to(:route).with(0..1).arguments }
 


### PR DESCRIPTION
This is an attempt at making the jumping forwards after reviewing pages (from 'check your answers') a bit nicer.

However; doing just this is problematic - if we just use `#next_incomplete_page` instead of `#next_page`, on the inital run though when there are pages that only have optional questions they'd be classed as valid and would be skipped.

So, there needs to be a way of knowing that we've made it to 'check your answers' and we want to jump straight back having made a quick change to an answer.

Additionally, if we change a answer that sends us down a different route, we don't want to jump back to the review page and instead want to make the user answer the alternate set of questions.
